### PR TITLE
Go style improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+PKGS = $(shell go list ./... | grep -v /vendor/)
 GO ?= go
 TMP_PATH ?= /tmp/gopath
 
@@ -6,11 +7,11 @@ all: test build
 get:
 	$(GO) get -u github.com/gorilla/mux
 	$(GO) get -u github.com/coreos/etcd/client
-	$(GO) get -u golang.org/x/net/context
+	$(GO) get -u github.com/pkg/errors
 	$(GO) get -u github.com/stretchr/testify/assert
 	
 test:
-	$(GO) test
+	$(GO) test $(PKGS)
 
 build:
 	$(GO) build
@@ -22,6 +23,6 @@ static_linux:
 	GOPATH=${TMP_PATH} go get -d -u -v \
 		github.com/gorilla/mux \
 		github.com/coreos/etcd/client \
-		golang.org/x/net/context
+		github.com/pkg/errors
 	cp -r * ${TMP_PATH}/src/github.com/slvwolf/ccentral
 	GOPATH=${TMP_PATH} env GOOS=linux GOARCH=amd64 $(GO) build -a -ldflags '-s' -tags netgo -installsuffix netgo -v -o ccentral


### PR DESCRIPTION
Some style improvements that make the project a bit more idiomatic Go.

* `make test` will now actually test all subpackages (you have to give go test a list of subpackages as arguments or it will test nothing)
* Don't log error text if you're going to return the error anyway. The caller should do the logging.
* If you want to add context to errors, wrap the error using pkg/errors, don't concatenate error strings
* Use the standard context package instead of the obsolete golang.org/x/net/context. They are identical as of Go 1.10.
* Check errors, even in json.Unmarshal
* Some other idiomatic Go style fixes